### PR TITLE
Restore current buffer after zooming out.

### DIFF
--- a/autoload/zoom.vim
+++ b/autoload/zoom.vim
@@ -22,8 +22,10 @@ endfunction
 
 function! zoom#toggle()
   if s:is_zoomed()
+    let l:current_buffer = bufnr('')
     exec 'silent! source' s:zoom_session_file()
     call setqflist(s:qflist)
+    silent! exe 'b'.l:current_buffer
     call s:set_zoomed()
   else
     let oldsessionoptions = &sessionoptions


### PR DESCRIPTION
Hi,
nice plugin, really simple solution. I found only one flaw:

1. Have multiple windows
2. Zoom in one of them
3. Open another buffer in the zoomed window
4. Zoom out

Currently it restores the buffer that was in the zoomed window before the zooming.

This fix makes sure your current buffer stays intact after you zoom out.	