### PR TITLE
Retain cursor position after un-zooming.

### DIFF
--- a/autoload/zoom.vim
+++ b/autoload/zoom.vim
@@ -26,11 +26,13 @@ endfunction
 
 function! zoom#toggle()
   if s:is_zoomed()
+    let cursor_pos = getpos('.')
     let l:current_buffer = bufnr('')
     exec 'silent! source' s:zoom_session_file()
     call setqflist(s:qflist)
     silent! exe 'b'.l:current_buffer
     call s:set_zoomed()
+    call setpos('.', cursor_pos)
   else
     " skip if only window
     if s:is_only_window() | return | endif


### PR DESCRIPTION
Hi there,

I have a suggestion for a pull request (feel free to disregard if you don't like this new behavior).  Basically, if you reposition the cursor while zoomed-in, that repositioning is lost when zooming-out.

Previous behavior was:
    Hit ctrl-w m to zoom into a window.
    Reposition cursor within that window.
    Hit ctrl-w m to zoom out to all windows.
    Cursor would be in the position it was in before zooming-in
    occurred.

I found that behavior jarring.

New behavior is:
    Hit ctrl-w m to zoom into a window.
    Reposition cursor within that window.
    Hit ctrl-w m to zoom out to all windows.
    Cursor remains where it was repositioned to.

Thanks,
Jason