### PR TITLE
zoom#toggle aborts when error (fix #9)

### DIFF
--- a/autoload/zoom.vim
+++ b/autoload/zoom.vim
@@ -28,7 +28,7 @@ function! s:zoom_session_file()
   return t:zoom_session_file
 endfunction
 
-function! zoom#toggle()
+function! zoom#toggle() abort
   if s:is_zoomed()
     if exists('#User#ZoomPre')
       doautocmd User ZoomPre


### PR DESCRIPTION
This PR solves the issue #9 :

> When I try to zoom in a window and there is changes in another file, occurs error E445 ("Other Window Contains Changes"). Variable zoomed is set to 1 anyway, this causes some strange behaviour like an adicional window with the same file opened.

As previously discussed, this issue can be solved by setting the `hidden` vim option, but this requires to modify one's vim config to solve this simple problem, which is not always possible.

A simpler way of approaching this is just to set the `zoom#toggle` function as `abort` so that the function execution stops when encountering the E445 error, and thus preserve the state of the zoomed variable.
This modification does not affect the plugin in any other ways.